### PR TITLE
Remove pip, system and subprocess import in the setup file

### DIFF
--- a/pymssa/mssa.py
+++ b/pymssa/mssa.py
@@ -7,7 +7,7 @@ from scipy.spatial.distance import cdist, pdist, squareform
 from scipy.linalg import hankel
 
 from functools import partial, lru_cache, reduce
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 
 from .optimized import *
 from .ops import *

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup, find_packages
-import subprocess
-import pip
-import sys
 
 REQUIREMENTS = [
     'pandas',


### PR DESCRIPTION
Remove unused import to ensure compatibility with virtual environment installation.