### PR TITLE
Fix tqdm.autonotebook warning in mssa.py

### DIFF
--- a/pymssa/mssa.py
+++ b/pymssa/mssa.py
@@ -7,7 +7,7 @@ from scipy.spatial.distance import cdist, pdist, squareform
 from scipy.linalg import hankel
 
 from functools import partial, lru_cache, reduce
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 
 from .optimized import *
 from .ops import *


### PR DESCRIPTION
Little fix to remove the tqdm.autonotebook warning.